### PR TITLE
Refactor playbook structure and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ Project Layout
   connection).
 - `inventories/local/group_vars/all.yml` – central place to set the
   `onepassword_*` variables.
-- `playbooks/setup.yml` – entry play that includes the `onepassword` role.
+- `playbooks/setup.yml` – umbrella playbook that imports the individual setup
+  plays.
+- `playbooks/setup_onepassword.yml` – installs the `onepassword` role.
+- `playbooks/setup_git.yml` – configures the SSH agent and clones GitHub
+  projects.
 - `roles/onepassword/` – installs the repository and layers packages via
   `community.general.rpm_ostree_pkg`.
 - `roles/onepassword_ssh_agent/` – configures dotfiles for the 1Password SSH
   agent on Linux when enabled.
+- `roles/github_projects/` – clones configurable GitHub repositories into a
+  configurable directory under the calling user.
 
 Requirements
 ------------
@@ -59,6 +65,15 @@ Override the defaults in `inventories/local/group_vars/all.yml` or with `-e`:
   (default `['*']`).
 - `onepassword_ssh_agent_create_symlink` – `false` (default). Set to `true` to
   link `~/.ssh/agent.sock` to the 1Password socket for legacy tooling.
+- `git_projects_clone_root` – `~/Projects-testing` (default). Base directory
+  where repositories are cloned.
+- `git_projects_repositories` – default list includes the
+  `will-isles/ansible-onepassword` and `will-isles/ansible-linux` repositories.
+  Override with a list of dictionaries containing `repo` URLs and optional
+  `name`/`dest` keys to manage additional projects.
+- `git_projects_git_user_name` / `git_projects_git_user_email` – set these when
+  you want the role to initialize your global Git identity. They default to
+  `null` so existing Git configurations are left untouched.
 
 Usage
 -----
@@ -68,6 +83,9 @@ Run against localhost and supply sudo credentials when prompted:
 ```sh
 ansible-playbook playbooks/setup.yml --ask-become-pass
 ```
+
+You can target only part of the workflow with
+`playbooks/setup_onepassword.yml` or `playbooks/setup_git.yml` as needed.
 
 You can limit to check mode first:
 

--- a/inventories/local/group_vars/all.yml
+++ b/inventories/local/group_vars/all.yml
@@ -7,3 +7,15 @@ onepassword_ssh_agent_enabled: true
 # onepassword_ssh_agent_manage_env: true
 # onepassword_ssh_agent_manage_ssh_config: true
 # onepassword_ssh_agent_create_symlink: false
+
+# github_projects variables control where repositories get cloned and which
+# repositories to manage.
+git_projects_clone_root: "~/Projects"
+git_projects_repositories:
+  - name: ansible-onepassword
+    repo: https://github.com/will-isles/ansible-onepassword
+  - name: ansible-linux
+    repo: https://github.com/will-isles/ansible-linux
+
+git_projects_git_user_name: null
+git_projects_git_user_email: null

--- a/playbooks/setup.yml
+++ b/playbooks/setup.yml
@@ -1,9 +1,3 @@
 ---
-- name: Install 1Password
-  hosts: local
-  gather_facts: false
-  any_errors_fatal: true
-  roles:
-    - role: onepassword
-    - role: onepassword_ssh_agent
-      when: (onepassword_ssh_agent_enabled | default(false)) | bool
+- import_playbook: setup_onepassword.yml
+- import_playbook: setup_git.yml

--- a/playbooks/setup_git.yml
+++ b/playbooks/setup_git.yml
@@ -1,0 +1,9 @@
+---
+- name: Configure Git tooling
+  hosts: local
+  gather_facts: false
+  any_errors_fatal: true
+  roles:
+    - role: onepassword_ssh_agent
+      when: (onepassword_ssh_agent_enabled | default(false)) | bool
+    - role: github_projects

--- a/playbooks/setup_onepassword.yml
+++ b/playbooks/setup_onepassword.yml
@@ -1,0 +1,7 @@
+---
+- name: Install 1Password
+  hosts: local
+  gather_facts: false
+  any_errors_fatal: true
+  roles:
+    - role: onepassword

--- a/roles/github_projects/defaults/main.yml
+++ b/roles/github_projects/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Configure locations and repositories managed by the github_projects role.
+git_projects_clone_root: "~/Projects-testing"
+
+git_projects_repositories:
+  - name: ansible-onepassword
+    repo: https://github.com/will-isles/ansible-onepassword
+  - name: ansible-linux
+    repo: https://github.com/will-isles/ansible-linux
+
+# Optional git identity defaults used when the host has no global configuration.
+git_projects_git_user_name: null
+git_projects_git_user_email: null

--- a/roles/github_projects/tasks/main.yml
+++ b/roles/github_projects/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Check existing git user.name
+  ansible.builtin.command: git config --global user.name
+  register: git_projects_existing_user_name
+  changed_when: false
+  failed_when: false
+  tags: [github_projects]
+
+- name: Configure git user.name when missing
+  when: git_projects_existing_user_name.rc != 0 or (git_projects_existing_user_name.stdout | default('') | trim == '')
+  tags: [github_projects]
+  block:
+    - name: Ensure git user.name default is provided
+      ansible.builtin.assert:
+        that:
+          - git_projects_git_user_name is defined
+          - (git_projects_git_user_name | string | trim | length) > 0
+        fail_msg: "Set git_projects_git_user_name to a non-empty value before running this play."
+    - name: Set git user.name
+      ansible.builtin.git_config:
+        name: user.name
+        scope: global
+        value: "{{ git_projects_git_user_name }}"
+
+- name: Check existing git user.email
+  ansible.builtin.command: git config --global user.email
+  register: git_projects_existing_user_email
+  changed_when: false
+  failed_when: false
+  tags: [github_projects]
+
+- name: Configure git user.email when missing
+  when: git_projects_existing_user_email.rc != 0 or (git_projects_existing_user_email.stdout | default('') | trim == '')
+  tags: [github_projects]
+  block:
+    - name: Ensure git user.email default is provided
+      ansible.builtin.assert:
+        that:
+          - git_projects_git_user_email is defined
+          - (git_projects_git_user_email | string | trim | length) > 0
+        fail_msg: "Set git_projects_git_user_email to a non-empty value before running this play."
+    - name: Set git user.email
+      ansible.builtin.git_config:
+        name: user.email
+        scope: global
+        value: "{{ git_projects_git_user_email }}"
+
+- name: Ensure clone root directory exists
+  ansible.builtin.file:
+    path: "{{ git_projects_clone_root }}"
+    state: directory
+    mode: "0755"
+  tags: [github_projects]
+
+- name: Clone configured repositories
+  ansible.builtin.git:
+    repo: "{{ item.repo }}"
+    dest: "{{ item.dest | default(git_projects_clone_root ~ '/' ~ (item.name | default((item.repo | regex_replace('.*/', '') | regex_replace('\\.git$', ''))))) }}"
+    update: true
+  loop: "{{ git_projects_repositories }}"
+  when: git_projects_repositories | length > 0
+  tags: [github_projects]


### PR DESCRIPTION
- Split `playbooks/setup.yml` into `setup_onepassword.yml` and `setup_git.yml` for clearer workflow targeting.
- Update README to reflect new playbook structure and document new variables for managing GitHub projects.